### PR TITLE
Remove unnecessary bottom scrollbar

### DIFF
--- a/src/components/styles/main.css
+++ b/src/components/styles/main.css
@@ -83,7 +83,7 @@ body {
   padding-top: 0;
   font-size: 1vw;
   max-height: 10vw;
-  overflow: scroll;
+  overflow-y: scroll;
 }
 
 #information h1 {


### PR DESCRIPTION
By removing the unnecessary bottom scrollbar, the information box will have a little more space